### PR TITLE
Add namespace replacement functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Utility module that provides options for modifying how metadata is displayed and
 * Search results
   * Hide metadata fields that contain no content.
   * Replace collection PID with collection label in search results.
+  * Replace object namespace with an arbitrary string in search results, using an arbitrary Solr field.
 * Embedded metadata
   * Add `<meta>` tags compatible with [Zotero](https://www.zotero.org/)
 * Metadata generation

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -39,18 +39,38 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
   $form['islandora_metadata_extras_search_results_configuration'] = array(
     '#type' => 'fieldset',
     '#title' => t('Search results'),
+    '#collapsible' => TRUE,
   );
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_hide_empty_values_in_search_results'] = array(
     '#type' => 'checkbox',
     '#title' => t('Hide empty fields in search results.'),
     '#default_value' => variable_get('islandora_metadata_extras_hide_empty_values_in_search_results', FALSE),
   );
+  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_rewrite_namespace'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Replace namespace according to a defined pattern.'),
+    '#default_value' => variable_get('islandora_metadata_extras_rewrite_namespace', FALSE),
+    '#collapsible' => TRUE,
+  );
+  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_namespace_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Namespace display field'),
+    '#description' => t('Solr field configured in search settings to display the namespace. Does not have to be a real field.');
+    '#default_value' => variable_get('islandora_metadata_extras_namespace_field', 'PID_namespace_ss'),
+  );
+  $default_replacements = "islandora|System\nir|Scholar";
+  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_namespace_replacements'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Namespace replacements'),
+    '#rows' => 10,
+    '#default_value' => variable_get('islandora_metadata_extras_namespace_replacements', $default_replacements),
+    '#description' => t("Place each namespace and replacement value pair, separated by a |, on its own line."),
+  );
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_use_collection_label'] = array(
     '#type' => 'checkbox',
     '#title' => t('Replace collection PID with collection label in search results.'),
     '#default_value' => variable_get('islandora_metadata_extras_use_collection_label', FALSE),
   );
-
   $form['islandora_metadata_extras_embedded_metadata'] = array(
     '#type' => 'fieldset',
     '#title' => t('Embedded metadata'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -55,7 +55,7 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_namespace_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Namespace display field'),
-    '#description' => t('Solr field configured in search settings to display the namespace. Does not have to be a real field.');
+    '#description' => t('Solr field configured in search settings to display the namespace. Does not have to be a real field.'),
     '#default_value' => variable_get('islandora_metadata_extras_namespace_field', 'PID_namespace_ss'),
   );
   $default_replacements = "islandora|System\nir|Scholar";

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -48,14 +48,19 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
   );
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_rewrite_namespace'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Replace namespace according to a defined pattern.'),
+    '#title' => t('Replace namespaces in search results according to a defined pattern.'),
     '#default_value' => variable_get('islandora_metadata_extras_rewrite_namespace', FALSE),
     '#collapsible' => TRUE,
   );
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_namespace_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Namespace display field'),
-    '#description' => t('Solr field configured in search settings to display the namespace. Does not have to be a real field.'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_metadata_extras_rewrite_namespace"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#description' => t('Solr field configured in search settings to display the namespace. Does not need to exist in your Solr configuration, but must be added to your Solr search result display fields (admin/islandora/search/islandora_solr/settings).'),
     '#default_value' => variable_get('islandora_metadata_extras_namespace_field', 'PID_namespace_ss'),
   );
   $default_replacements = "islandora|System\nir|Scholar";
@@ -63,6 +68,11 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
     '#type' => 'textarea',
     '#title' => t('Namespace replacements'),
     '#rows' => 10,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_metadata_extras_rewrite_namespace"]' => array('checked' => TRUE),
+      ),
+    ),
     '#default_value' => variable_get('islandora_metadata_extras_namespace_replacements', $default_replacements),
     '#description' => t("Place each namespace and replacement value pair, separated by a |, on its own line."),
   );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -31,6 +31,27 @@ function islandora_metadata_extras_pid_to_label($pid) {
 }
 
 /**
+ * Given a PID, returns namespace converted according to replacement patterns.
+ *
+ * @param string $pid
+ *   The PID from the search result.
+ *
+ * @return string
+ *   The object's original or converted namespace.
+ */
+function islandora_metadata_extras_namespace_to_label($pid) {
+  $namespace = substr($pid, 0, strpos($pid, ':'));
+  $replacements = variable_get('islandora_metadata_extras_namespace_replacements', "islandora|System\nir|System");
+  $replacements_array = preg_split('/\r\n|\n|\r/', $replacements, -1, PREG_SPLIT_NO_EMPTY);
+
+  foreach ($replacements_array as $replacement) {
+    list($before, $after) = explode('|', $replacement);
+    $namespace = preg_replace('/' . $before . '/', trim($after), $namespace);
+  }
+  return $namespace;
+}
+
+/**
  * Adds an identifier element containing a UUID to a MODS datastream.
  *
  * @param string $pid
@@ -114,4 +135,16 @@ function islandora_metadata_extras_get_dc_values($xml) {
  */
 function islandora_metadata_extras_get_uuid() {
   return shell_exec('uuidgen');
+}
+
+function islandora_doi_datacite_normalize_resourcetype($resourcetypes) {
+  $replacements = variable_get('islandora_doi_datacite_resourcetype_replacements', "StillImage|Image\nThesis|Text");
+  $replacements_array = preg_split('/\r\n|\n|\r/', $replacements, -1, PREG_SPLIT_NO_EMPTY);
+  foreach ($resourcetypes as &$resourcetype) {
+    foreach ($replacements_array as $replacement) {
+      list($before, $after) = explode('|', $replacement);
+      $resourcetype = preg_replace('/' . $before . '/', trim($after), $resourcetype);
+    }
+  }
+  return $resourcetypes[0];
 }

--- a/islandora_metadata_extras.module
+++ b/islandora_metadata_extras.module
@@ -53,14 +53,19 @@ function islandora_metadata_extras_islandora_view_object($object) {
  * Implements hook_islandora_solr_object_result_alter().
  */
 function islandora_metadata_extras_islandora_solr_object_result_alter(&$search_result, $query_processor) {
+  module_load_include('inc', 'islandora_metadata_extras', 'includes/utilities');
   if (variable_get('islandora_metadata_extras_use_collection_label', FALSE)) {
-    module_load_include('inc', 'islandora_metadata_extras', 'includes/utilities');
     $collection_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
     if (isset($search_result['solr_doc'][$collection_field]) && is_array($search_result['solr_doc'][$collection_field])) {
       foreach ($search_result['solr_doc'][$collection_field] as $collection_pid) {
         $search_result['solr_doc'][$collection_field] = islandora_metadata_extras_pid_to_label($collection_pid);
       }
     }
+  }
+  if (variable_get('islandora_metadata_extras_rewrite_namespace', FALSE)) {
+    $namespace_field = variable_get('islandora_metadata_extras_namespace_field', 'PID_namespace_ss');
+    $pid = $search_result['solr_doc']['PID'];
+    $search_result['solr_doc'][$namespace_field] = islandora_metadata_extras_namespace_to_label($pid);
   }
 }
 


### PR DESCRIPTION
Allows an admin to define a set of namespaces, along with replacements for displaying them in search results.

Adds three config fields:

- Checkbox to turn on namespace replacement
- Solr field for displaying namespaces (does not have to really exist, but does have to be added to Solr settings)
- Set of namespaces and replacement values

Takes the object's PID, extracts namespace, then transforms it according to the replacement configuration if applicable. If there's a replacement, return the replacement to the search results. If no replacement is configured, return the namespace as-is.

**Testing**

1. In the Config form, check off the new Namespace replacement option and define some namespace replacements.
2. Add a namespace display field. Does not have to be a real one.
3. In Solr settings, add that namespace display field to your search results fields.
4. Run a search. Resulting objects' namespaces should appear in the field you added. Namespaces matching your replacements will be replaced. Namespaces that have no replacement matches will appear unchanged.