### PR TITLE
Change regex replacement to if equals string

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -43,10 +43,11 @@ function islandora_metadata_extras_namespace_to_label($pid) {
   $namespace = substr($pid, 0, strpos($pid, ':'));
   $replacements = variable_get('islandora_metadata_extras_namespace_replacements', "islandora|System\nir|System");
   $replacements_array = preg_split('/\r\n|\n|\r/', $replacements, -1, PREG_SPLIT_NO_EMPTY);
-
   foreach ($replacements_array as $replacement) {
     list($before, $after) = explode('|', $replacement);
-    $namespace = preg_replace('/' . $before . '/', trim($after), $namespace);
+    if ($namespace == $before) {
+      $namespace = $after;
+    }
   }
   return $namespace;
 }


### PR DESCRIPTION
# Github issue

Fixes #30

# What does this Pull Request do?

In the last step of the Namespace Replacement feature, use an exact match instead of regex to make the replacement. This fixes the problem of the module identifying a match in part of a string.

# How should this be tested?
## Setup
* In Islandora Metadata Extras config, enable the Namespace Replacement section
* Add the following:
```
ir|Scholar
irate|Test
```
* Configure your search results to display the Namespace field as configured in Metadata Extras (does not have to be a real field in your Solr index). Give it the label "Namespace"
* Create two new objects with the same keyword in their titles (e.g. "bugaboo") - one in the "ir" namespace and one in the "irate" namespace.

## Reproduce the problem
* Search for the keyword
* Expected results in the "Namespace" field: the "ir" object will read "Scholar". The "irate" object will read "Scholarate".

## Test this PR
* Check out this branch and refresh search results
* New results in "Namespace" field: the "ir" object will read "Scholar". The "irate" object will read "Test".

# Interested parties

@mjordan 