### PR TITLE
Replace facet labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Utility module that provides options for modifying how metadata is displayed and
 * Search results
   * Hide metadata fields that contain no content.
   * Replace collection PID with collection label in search results.
+  * Replace the values displayed in the search facet sidebar for selected Solr fields. Does not apply to Facet Pages.
   * Replace object namespace with an arbitrary string in search results, using an arbitrary Solr field.
 * Embedded metadata
   * Add `<meta>` tags compatible with [Zotero](https://www.zotero.org/).
@@ -43,6 +44,10 @@ Configuration options are available at Administration > Islandora > Islandora Ut
 * To replace the collection PID with its human-readable label:
   1. add the field that stores your objects' collecion PID to your Solr search results, just like you would for any other field. The name of this field is configured in Administration > Islandora> Solr Index > Solr Settings > Required Solr Fields > The isMemberOfCollection Solr field. The default values is "RELS_EXT_isMemberOfCollection_uri_ms".
   1. enable the option in the Metadata Extras admin options form. Note that not all Islandora objects are direct members of a collection; for example, children of compound objects, and newspaper and book pages.
+* To rewrite the text of facet values in the search sidebar:
+  1. Enable this option in the Metadata Extras admin options.
+  2. Enter the Solr field whose values you wish to rewrite. It must be one of your configured facet fields.
+  3. Enter the values you expect, followed by the pipe "|" character, and the values you wish to replace them with.
 * To add `<meta>` tags containing Dublin Core metadata:
   * Enable this option in the Metadata Extras admin options. No other configuration is necessary. This module provides a hook that allows other modules to alter the metadata before it is added to the page markup. See islandora_metadata_extras.api.php for more information.
 * To display datastream checksums within an object's Manage > Datastreams tab:

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -80,6 +80,38 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
     '#title' => t('Replace collection PID with collection label in search results.'),
     '#default_value' => variable_get('islandora_metadata_extras_use_collection_label', FALSE),
   );
+
+  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_rewrite_facets'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Replace facet values with configured text.'),
+    '#default_value' => variable_get('islandora_metadata_extras_rewrite_facets', FALSE),
+    '#collapsible' => TRUE,
+  );
+  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Facet display field'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_metadata_extras_rewrite_facets"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#description' => t('Solr field used for the target facet.'),
+    '#default_value' => variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms'),
+  );
+  $default_facet_replacements = "";
+  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_replacements'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Facet value replacements'),
+    '#rows' => 10,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_metadata_extras_rewrite_facets"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#default_value' => variable_get('islandora_metadata_extras_facet_replacements', $default_facet_replacements),
+    '#description' => t("Place each original value and replacement value pair, separated by a |, on its own line."),
+  );
+
   $form['islandora_metadata_extras_embedded_metadata'] = array(
     '#type' => 'fieldset',
     '#title' => t('Embedded metadata'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -87,6 +87,17 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
     '#default_value' => variable_get('islandora_metadata_extras_rewrite_facets', FALSE),
     '#collapsible' => TRUE,
   );
+  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Facet display field to replace'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_metadata_extras_rewrite_facets"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#description' => t('Solr field for the facet you wish to transform.'),
+    '#default_value' => variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms'),
+  );
   $default_facet_replacements = "";
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_replacements'] = array(
     '#type' => 'textarea',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -87,17 +87,6 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
     '#default_value' => variable_get('islandora_metadata_extras_rewrite_facets', FALSE),
     '#collapsible' => TRUE,
   );
-  $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_field'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Facet display field'),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="islandora_metadata_extras_rewrite_facets"]' => array('checked' => TRUE),
-      ),
-    ),
-    '#description' => t('Solr field used for the target facet.'),
-    '#default_value' => variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms'),
-  );
   $default_facet_replacements = "";
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_replacements'] = array(
     '#type' => 'textarea',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -86,6 +86,7 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
     '#title' => t('Replace facet values with configured text.'),
     '#default_value' => variable_get('islandora_metadata_extras_rewrite_facets', FALSE),
     '#collapsible' => TRUE,
+    '#description' => t('Rewrite the facet values displayed in your search sidebar for selected Solr fields. Does not affect Facet Pages.'),
   );
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_field'] = array(
     '#type' => 'textfield',

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -53,6 +53,39 @@ function islandora_metadata_extras_namespace_to_label($pid) {
 }
 
 /**
+ * Given a facet value, returns text converted according to replacement patterns.
+ *
+ * @param string $value
+ *   The facet value from the search result.
+ *
+ * @return string
+ *   The object's original or converted namespace.
+ */
+function islandora_metadata_extras_facet_convert($value) {
+
+  // Todo: break apart the string, get the bit between > and </a>, modify that and preseve the rest
+  $value_split = explode(">", $value);
+  $value_first = $value_split[0] . ">";
+  $value_last = "</a>";
+  $value_content = explode("</a", $value_split[1]);
+  $value_content = $value_content[0];
+
+  $replacements = variable_get('islandora_metadata_extras_facet_replacements', "");
+  $replacements_array = preg_split('/\r\n|\n|\r/', $replacements, -1, PREG_SPLIT_NO_EMPTY);
+  foreach ($replacements_array as $replacement) {
+    list($before, $after) = explode('|', $replacement);
+    if ($value_content == $before) {
+      $value_content = $after;
+    }
+  }
+
+  $value = $value_first . $value_content . $value_last;
+
+  return $value;
+}
+
+
+/**
  * Adds an identifier element containing a UUID to a MODS datastream.
  *
  * @param string $pid

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -62,25 +62,14 @@ function islandora_metadata_extras_namespace_to_label($pid) {
  *   The object's original or converted namespace.
  */
 function islandora_metadata_extras_facet_convert($value) {
-
-  // Todo: break apart the string, get the bit between > and </a>, modify that and preseve the rest
-  $value_split = explode(">", $value);
-  $value_first = $value_split[0] . ">";
-  $value_last = "</a>";
-  $value_content = explode("</a", $value_split[1]);
-  $value_content = $value_content[0];
-
   $replacements = variable_get('islandora_metadata_extras_facet_replacements', "");
   $replacements_array = preg_split('/\r\n|\n|\r/', $replacements, -1, PREG_SPLIT_NO_EMPTY);
   foreach ($replacements_array as $replacement) {
     list($before, $after) = explode('|', $replacement);
-    if ($value_content == $before) {
-      $value_content = $after;
+    if ($value == $before) {
+      $value = $after;
     }
   }
-
-  $value = $value_first . $value_content . $value_last;
-
   return $value;
 }
 

--- a/islandora_metadata_extras.module
+++ b/islandora_metadata_extras.module
@@ -118,14 +118,17 @@ function islandora_metadata_extras_islandora_solr_object_result_alter(&$search_r
 
 
 /**
- * Implements hook_islandora_solr_facet_variables_alter().
+ * Implements hook_islandora_solr_facet_bucket_classes_alter().
  */
-function islandora_metadata_extras_islandora_solr_facet_variables_alter(&$facets, &$facet_field) {
+function islandora_metadata_extras_islandora_solr_facet_bucket_classes_alter(&$buckets, $query_processor) {
   if (variable_get('islandora_metadata_extras_rewrite_facets', FALSE)) {
     $facet_field_configured = variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms');
-    foreach ($facets AS &$facet) {
-      $facet['link'] = islandora_metadata_extras_facet_convert($facet['link']);
-    }          
+    foreach ($buckets AS &$facet) {
+      $facet_used = explode(":", $facet_field_configured);
+      if (in_array($facet_field_configured, $facet_used)) {
+        $facet['label'] = islandora_metadata_extras_facet_convert($facet['label']);
+      }
+    } 
   }
 }
 

--- a/islandora_metadata_extras.module
+++ b/islandora_metadata_extras.module
@@ -116,6 +116,26 @@ function islandora_metadata_extras_islandora_solr_object_result_alter(&$search_r
   }
 }
 
+
+/**
+ * Implements hook_islandora_solr_facet_variables_alter().
+ */
+function islandora_metadata_extras_islandora_solr_facet_variables_alter(&$facets) {
+
+  if (variable_get('islandora_metadata_extras_rewrite_facets', FALSE)) {
+    $facet_field = variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms');
+    $facets_new = array();
+    foreach ($facets AS $facet) {
+      $facet['link'] = islandora_metadata_extras_facet_convert($facet['link']);
+      $facets_new[] = $facet;
+    }          
+  }
+dd($facets_new);
+$facets = $facets_new;
+return($facets);
+}
+
+
 /**
  * Implements hook_islandora_view_object_alter().
  */

--- a/islandora_metadata_extras.module
+++ b/islandora_metadata_extras.module
@@ -120,9 +120,9 @@ function islandora_metadata_extras_islandora_solr_object_result_alter(&$search_r
 /**
  * Implements hook_islandora_solr_facet_variables_alter().
  */
-function islandora_metadata_extras_islandora_solr_facet_variables_alter(&$facets) {
+function islandora_metadata_extras_islandora_solr_facet_variables_alter(&$facets, &$facet_field) {
   if (variable_get('islandora_metadata_extras_rewrite_facets', FALSE)) {
-    $facet_field = variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms');
+    $facet_field_configured = variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms');
     foreach ($facets AS &$facet) {
       $facet['link'] = islandora_metadata_extras_facet_convert($facet['link']);
     }          

--- a/islandora_metadata_extras.module
+++ b/islandora_metadata_extras.module
@@ -121,18 +121,12 @@ function islandora_metadata_extras_islandora_solr_object_result_alter(&$search_r
  * Implements hook_islandora_solr_facet_variables_alter().
  */
 function islandora_metadata_extras_islandora_solr_facet_variables_alter(&$facets) {
-
   if (variable_get('islandora_metadata_extras_rewrite_facets', FALSE)) {
     $facet_field = variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms');
-    $facets_new = array();
-    foreach ($facets AS $facet) {
+    foreach ($facets AS &$facet) {
       $facet['link'] = islandora_metadata_extras_facet_convert($facet['link']);
-      $facets_new[] = $facet;
     }          
   }
-dd($facets_new);
-$facets = $facets_new;
-return($facets);
 }
 
 


### PR DESCRIPTION
Handles issue #20 

Now that https://github.com/Islandora/islandora_solr_search/pull/370 has been merged, this will work.

# What does this Pull Request do?

Using the new features in hook_islandora_solr_facet_bucket_classes_alter() to modify the facet label, allows you to define a string from a search facet and replace it with an alternative.

# How should this be tested?

- Take a known value in your facets and configure a replacement in the module (Islandora Utility Modules -> Metadata Extras, check "Replace facet values with configured text", and enter oldvalue|newvalue
    - Example: include a Rights Statement URI in the mods_accessCondition_use_and_reproduction_ms field. Include that field in your facets. In the Islandora Metadata Extras settings, replace the URI with the Rights Statements label.
- Run a search, and see that the displaying for your facet has changed

# Interested parties

@mjordan 