### PR TITLE
Fix offset error

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -64,10 +64,13 @@ function islandora_metadata_extras_namespace_to_label($pid) {
 function islandora_metadata_extras_facet_convert($value) {
   $replacements = variable_get('islandora_metadata_extras_facet_replacements', "");
   $replacements_array = preg_split('/\r\n|\n|\r/', $replacements, -1, PREG_SPLIT_NO_EMPTY);
+  $break_character = "|";
   foreach ($replacements_array as $replacement) {
-    list($before, $after) = explode('|', $replacement);
-    if ($value == $before) {
-      $value = $after;
+    if (strpos($replacement, $break_character) !== false) {
+      list($before, $after) = explode($break_character, $replacement);
+      if ($value == $before) {
+        $value = $after;
+      }
     }
   }
   return $value;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -43,10 +43,13 @@ function islandora_metadata_extras_namespace_to_label($pid) {
   $namespace = substr($pid, 0, strpos($pid, ':'));
   $replacements = variable_get('islandora_metadata_extras_namespace_replacements', "islandora|System\nir|System");
   $replacements_array = preg_split('/\r\n|\n|\r/', $replacements, -1, PREG_SPLIT_NO_EMPTY);
+  $break_character = "|";
   foreach ($replacements_array as $replacement) {
-    list($before, $after) = explode('|', $replacement);
-    if ($namespace == $before) {
-      $namespace = $after;
+    if (strpos($replacement, $break_character) !== false) {
+      list($before, $after) = explode($break_character, $replacement);
+      if ($namespace == $before) {
+        $namespace = $after;
+      }
     }
   }
   return $namespace;

--- a/islandora_metadata_extras.module
+++ b/islandora_metadata_extras.module
@@ -253,3 +253,34 @@ function islandora_metadata_extras_edit_metadata_direct_link($object) {
   return t('This object does not have any of the configured datastreams (!dsids).',
     array('!dsids' => $configured_dsids));
 }
+
+/**
+ * Implements validation from the Form API.
+ * 
+ * @param $form
+ *   A structured array containing the elements and properties of the form.
+ * @param $form_state
+ *   An array that stores information about the form's current state 
+ *   during processing.
+ */
+function islandora_metadata_extras_admin_form_validate($form, &$form_state){
+  $break_character = "|";
+  $rewrite_namespace = $form_state['values']['islandora_metadata_extras_rewrite_namespace'];
+  $rewrite_facets = $form_state['values']['islandora_metadata_extras_rewrite_facets'];
+  if ($rewrite_namespace == 1) {
+    $namespace_replacements = explode("\n", $form_state['values']['islandora_metadata_extras_namespace_replacements']);
+    foreach ($namespace_replacements AS $replacement) {
+      if (strpos($replacement, $break_character) == false) {
+        form_set_error('islandora_metadata_extras', t('One or more of your replacements is missing the | character.'));
+      }
+    }
+  }
+  if ($rewrite_facets == 1) {
+    $facet_replacements = explode("\n", $form_state['values']['islandora_metadata_extras_facet_replacements']);
+    foreach ($facet_replacements AS $replacement) {
+      if (strpos($replacement, $break_character) == false) {
+        form_set_error('islandora_metadata_extras', t('One or more of your replacements is missing the | character.'));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Error noted in #32: 

> Noted an issue here. Every time there's a search, this appears in the logs:
> 
> `Notice: Undefined offset: 1 in islandora_metadata_extras_facet_convert() (line 68 of /var/www/html/drupal7/sites/all/modules/islandora_metadata_extras/includes/utilities.inc).`
> 
> This happens only in my production site; not in Vagrant.
> 
> Is it possible there might be an out of date module creating this conflict? Do you get similar results?

# What does this Pull Request do?

Currently, if user forgets to include the `|` character in the list of replacements, result is an Undefined Offset error which is written to the logs. Given how the module works, this means hundreds of Undefined Offset errors every hour on a busy site.

This PR checks each replacement string to make sure the `|` is actually present, before it tries to explode it.

# What's new?

In the two Replacement fields, code is introduced to check for the presence of the `|` before attempting to explode and replace. If the `|` is not present in that particular string, the replacement process is skipped.


# How should this be tested?

Configure your text replacements as normal, in a way that should generate results. Run a search and confirm that replacements are happening.

In one of your replacements, remove the `|` and re-run your search. Check the Drupal log and see the Undefined Offset error.

Check out this PR and re-run the search. No error reported.

**Question**: should we introduce some lines to report to the administrator what the problem is? Is this a watchdog error that runs during the replacement process, or is it something we can catch when saving your config via the admin form?

# Interested parties

@mjordan 
