### PR TITLE
Add multiple solr field config to facet option

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -90,13 +90,13 @@ function islandora_metadata_extras_admin_form(array $form, array &$form_state) {
   );
   $form['islandora_metadata_extras_search_results_configuration']['islandora_metadata_extras_facet_field'] = array(
     '#type' => 'textfield',
-    '#title' => t('Facet display field to replace'),
+    '#title' => t('Facet display fields to replace'),
     '#states' => array(
       'visible' => array(
         ':input[name="islandora_metadata_extras_rewrite_facets"]' => array('checked' => TRUE),
       ),
     ),
-    '#description' => t('Solr field for the facet you wish to transform.'),
+    '#description' => t('Solr fields for the facets you wish to transform. If entering multiple fields, separate them with a space'),
     '#default_value' => variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms'),
   );
   $default_facet_replacements = "";

--- a/islandora_metadata_extras.module
+++ b/islandora_metadata_extras.module
@@ -122,12 +122,15 @@ function islandora_metadata_extras_islandora_solr_object_result_alter(&$search_r
  */
 function islandora_metadata_extras_islandora_solr_facet_bucket_classes_alter(&$buckets, $query_processor) {
   if (variable_get('islandora_metadata_extras_rewrite_facets', FALSE)) {
-    $facet_field_configured = variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms');
+    $facet_fields_configured = variable_get('islandora_metadata_extras_facet_field', 'mods_accessCondition_use_and_reproduction_ms');
+    $facet_fields_configured = explode(" ", $facet_fields_configured);
     foreach ($buckets AS &$facet) {
       $test = $facet['query']['f']['0'];
       if (isset($test)) {
-        if (strpos($test, $facet_field_configured) !== false) {
-          $facet['label'] = islandora_metadata_extras_facet_convert($facet['label']);
+        foreach ($facet_fields_configured AS $facet_field) {
+          if (strpos($test, $facet_field) !== false) {
+            $facet['label'] = islandora_metadata_extras_facet_convert($facet['label']);
+          }
         }
       }
     } 


### PR DESCRIPTION
Addresses #33 (more or less)

# What does this Pull Request do?

Allows the user to specify multiple Solr fields for facet replacements, separated by a space.

# What's new?

New helptext for field config, now checks for multiple configured Solr fields when replacing facets.

Note: there is still just one field to handle all replacements. If someone specified two Solr fields that could conceivably have the same values and different replacements, that would be a problem. But that is an extreme edge case, I think, and could be dealt with later.

# How should this be tested?

- Set up multiple facets
- Run a search to see the values in those facets
- Configure Islandora Metadata Extras to use two of those facet fields, and to replace values returned in two different facets
- See the results

# Interested parties

@mjordan 