### PR TITLE
fixed bug related to month not being 0 indexed

### DIFF
--- a/js/convert_date_values.js
+++ b/js/convert_date_values.js
@@ -25,7 +25,7 @@
       if (datePattern.test(fieldValue)) {
         dateParts = fieldValue.split("-");
         var year = dateParts[0];
-        var month = dateParts[1];
+        var month = dateParts[1] - 1;
         var date = new Date(year, month);
         month = date.toLocaleString(Drupal.settings.islandora_metadata_extras.locale, { month: "long" });
         var textDate = month + ' ' + year;


### PR DESCRIPTION
# Github issue

https://github.com/bondjimbond/islandora_metadata_extras/issues/41 

# What does this Pull Request do?

Subtracts one from the month in the YYYY-MM datePattern section so that the month is zero indexed.

# How should this be tested?

With this module enabled, and the "Replace yyyy-mm-dd and yyyy-mm dates in object metadata displays with human-readable equivalents." option enabled, view an item that has YYYY-MM metadata and make sure it converts it to the correct human-readable equivalent.

